### PR TITLE
Disable lintOnFly

### DIFF
--- a/lib/linter-perl.coffee
+++ b/lib/linter-perl.coffee
@@ -13,7 +13,7 @@ module.exports = class LinterPerl
   grammarScopes: ["source.perl"]
   name: "B::Lint"
   scope: "file"
-  lintOnFly: true
+  lintOnFly: false
 
   #---
 


### PR DESCRIPTION
As B::Lint is only running on the state of the file on disk, this should be set to false so it isn't repeatedly called whenever a change is made to the active editor.

Closes #40.