### PR TITLE
Update to atom-package-deps v4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     }
   },
   "dependencies": {
-    "atom-package-deps": "^3.0.1",
+    "atom-package-deps": "^4.6.0",
     "grim": "^1.4.1",
     "lodash": "^3.10.0"
   },


### PR DESCRIPTION
Update to the latest version of `atom-package-deps`.

Fixes #39.
Closes #41.