### PR TITLE
Use atom-linter to generate ranges

### DIFF
--- a/lib/linter-perl.coffee
+++ b/lib/linter-perl.coffee
@@ -7,6 +7,7 @@ _ = {
   isEqual: require "lodash/lang/isEqual"
 }
 util = require "./util"
+helpers = require 'atom-linter'
 
 module.exports = class LinterPerl
 
@@ -59,13 +60,10 @@ module.exports = class LinterPerl
           m = line.match RE
           continue unless m and m.length is 4
           [unused, message, filePath, lineNum] = m
-          range = null
-          buffer = textEditor.getBuffer()
-          if lineNum <= buffer.getLineCount()
-            range = [
-              [lineNum-1, 0]
-              [lineNum-1, buffer.lineLengthForRow(lineNum-1)]
-            ]
+          try
+            range = helpers.generateRange(textEditor, lineNum - 1)
+          catch error
+            range = null
           if range and message?.length
             results.push {
               type: 'Error'

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     }
   },
   "dependencies": {
+    "atom-linter": "^10.0.0",
     "atom-package-deps": "^4.6.0",
     "grim": "^1.4.1",
     "lodash": "^3.10.0"


### PR DESCRIPTION
Since B::Lint only gives back a line number, use `atom-linter` to generate a range encompassing just the text of the line, instead of the entirety of the line.

Before:
![image](https://user-images.githubusercontent.com/427137/36323917-78096d94-1307-11e8-80e4-1fc37d5f7a7f.png)

After:
![image](https://user-images.githubusercontent.com/427137/36323957-a690e82c-1307-11e8-8623-e41dbaa877b4.png)

Note:
Invalid points will result in a `null` range, since `atom-linter` checks that points are valid and `throw`s an Error in that case. Currently this is just hidden from the user, but can be handled better in the future.